### PR TITLE
feat: add minimize/restore pane keybindings

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -40,7 +40,12 @@ bind -r K swap-pane -s '{up-of}'         # swap with pane above
 
 bind-key n command-prompt -p "Rename pane:" "select-pane -T '%%'"
 
+# Minimize pane (break out to hidden window) / restore it back
+bind-key M break-pane -d  # minimize: send pane to its own window (hidden, -d = don't switch to it)
+bind-key R choose-window 'join-pane -s "%%"'  # restore: pick minimized pane within current session
+
 set -g mouse on
+set -g renumber-windows on
 
 set-window-option -g mode-keys vi
 


### PR DESCRIPTION
## Summary
- `prefix+M`: break current pane to a hidden background window (minimize)
- `prefix+R`: open window picker to join a pane back (restore)
- `renumber-windows on` to keep window indices sequential after break/join

## Test plan
- [x] Split a window into multiple panes
- [x] `prefix+M` on one pane — it disappears from the layout
- [x] `prefix+R` — window picker appears, select the minimized pane to restore it
- [x] Minimize 2+ panes and verify picker shows all of them
- [x] Verify window numbers stay sequential (0, 1, 2...) after operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)